### PR TITLE
Remove println stacktrace

### DIFF
--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -227,9 +227,6 @@ function TAP12Producer() {
     if (err.message) {
       println(err.message.replace(/^/gm, '  '));
     }
-    if (err.stack) {
-      println(err.stack.replace(/^/gm, '  '));
-    }
   };
 }
 


### PR DESCRIPTION
tap.jsのstacktraceの表示を削除する
