### PR TITLE
Remove error message to TAP

### DIFF
--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -224,9 +224,6 @@ function TAP12Producer() {
    */
   this.writeFail = function(n, test, err) {
     TAPProducer.prototype.writeFail.call(this, n, test, err);
-    if (err.message) {
-      println(err.message.replace(/^/gm, '  '));
-    }
     if (err.stack) {
       println(err.stack.replace(/^/gm, '  '));
     }


### PR DESCRIPTION
TAPで二重にエラーメッセージが出る問題があるので消す